### PR TITLE
NYCFC command updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 database.sqlite
+nycCache.json

--- a/bot/helper/nycfc/checkCache.js
+++ b/bot/helper/nycfc/checkCache.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+
+const checkCache = async () => {
+    try {
+        const nycCacheData = fs.readFileSync(path.join(__dirname, 'nycCache.json'), 'utf8');
+        const nycCache = JSON.parse(nycCacheData);
+        if (Object.keys(nycCache).length === 3) return true;
+        return false;
+    } catch (error) {
+        return false;
+    }
+}
+
+module.exports = checkCache;

--- a/bot/helper/nycfc/getCache.js
+++ b/bot/helper/nycfc/getCache.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+
+const getCache = async () => {
+    try {
+        const nycCacheData = fs.readFileSync(path.join(__dirname, 'nycCache.json'), 'utf8');
+        const nycCache = JSON.parse(nycCacheData);
+        if (Object.keys(nycCache).length === 3) return nycCache;
+        return false;
+    } catch (error) {
+        return false;
+    }
+}
+
+module.exports = getCache;

--- a/bot/helper/nycfc/getMatchData.js
+++ b/bot/helper/nycfc/getMatchData.js
@@ -1,4 +1,5 @@
-const axios = require("axios");
+const fs = require('fs');
+const getCache = require('./getCache');
 
 const cleanMatchData = async (data) => {
   const pastMatchesRaw = [];
@@ -13,6 +14,7 @@ const cleanMatchData = async (data) => {
   const upcomingMatches = {};
 
   pastMatchesRaw.forEach((match) => {
+    if (match.league.name === 'Friendlies Clubs') return;
     pastMatches.push({
       date: match.fixture.date,
       home: match.teams.home.name,
@@ -23,23 +25,25 @@ const cleanMatchData = async (data) => {
   });
 
   let setNextMatch = false;
+  let setNextClosest = false;
   upcomingMatchesRaw.forEach((match) => {
-    if (!setNextMatch) {
+    if (!setNextMatch && match.fixture.venue.city !== "New York City") {
       upcomingMatches.nextMatch = {
         date: match.fixture.date,
         home: match.teams.home.name,
         away: match.teams.away.name,
         venue: match.fixture.venue.name,
       };
+      setNextMatch = true;
     }
-    setNextMatch = true;
-    if (match.fixture.venue.city === "New York City") {
+    if (!setNextClosest && match.fixture.venue.city === "New York City") {
       upcomingMatches.nextClosest = {
         date: match.fixture.date,
         home: match.teams.home.name,
         away: match.teams.away.name,
         venue: match.fixture.venue.name,
       };
+      setNextClosest = true;
     }
   });
 
@@ -47,25 +51,14 @@ const cleanMatchData = async (data) => {
 };
 
 const getMatchData = async () => {
-  const options = {
-    method: "GET",
-    url: "https://api-football-v1.p.rapidapi.com/v3/fixtures",
-    params: {
-      season: new Date().getUTCFullYear(),
-      team: "1604",
-    },
-    headers: {
-      "x-rapidapi-key": "7d72abfd87msh1e1ee55e26e1abap1c4abejsncb2927f36be6",
-      "x-rapidapi-host": "api-football-v1.p.rapidapi.com",
-    },
-  };
+  let nycCache = await getCache();
 
-  try {
-    const res = await axios.request(options);
-    return cleanMatchData(res.data.response);
-  } catch (error) {
-    console.error(error);
-  }
+    try {
+      const fixturesData = nycCache.fixturesData;
+      return cleanMatchData(fixturesData);
+    } catch (error) {
+      console.log(error);
+    }
 };
 
 module.exports = getMatchData;

--- a/bot/helper/nycfc/getTeamStats.js
+++ b/bot/helper/nycfc/getTeamStats.js
@@ -1,26 +1,14 @@
-const axios = require('axios');
+const fs = require('fs');
+const getCache = require('./getCache');
 
 const getTeamStats = async () => {
-    const options = {
-        method: 'GET',
-        url: 'https://api-football-v1.p.rapidapi.com/v3/teams/statistics',
-        params: {
-          league: '253',
-          season: new Date().getUTCFullYear(),
-          team: '1604'
-        },
-        headers: {
-          'x-rapidapi-key': '7d72abfd87msh1e1ee55e26e1abap1c4abejsncb2927f36be6',
-          'x-rapidapi-host': 'api-football-v1.p.rapidapi.com'
-        }
-      };
-      
-      try {
-          const res = await axios.request(options);
-          return res.data.response;
-      } catch (error) {
-          console.error(error);
-      }
+    let nycCache = await getCache();
+
+    try {
+        return nycCache.statsData;
+    } catch (error) {
+        console.log(error);
+    }
 }
 
 module.exports = getTeamStats;

--- a/bot/helper/nycfc/refreshNycData.js
+++ b/bot/helper/nycfc/refreshNycData.js
@@ -1,0 +1,67 @@
+const axios = require("axios");
+require('dotenv').config();
+const fs = require('fs');
+const path = require("path");
+const getCache = require("./getCache");
+
+const refreshNycData = async () => {
+    const apiKey = process.env.RAPIDAPIKEY;
+
+    const optionsFixtures = {
+      method: "GET",
+      url: "https://api-football-v1.p.rapidapi.com/v3/fixtures",
+      params: {
+        season: new Date().getUTCFullYear(),
+        team: "1604",
+      },
+      headers: {
+        "x-rapidapi-key": `${apiKey}`,
+        "x-rapidapi-host": "api-football-v1.p.rapidapi.com",
+      },
+    };
+
+    const optionsStats = {
+        method: 'GET',
+        url: 'https://api-football-v1.p.rapidapi.com/v3/teams/statistics',
+        params: {
+          league: '253',
+          season: new Date().getUTCFullYear(),
+          team: '1604'
+        },
+        headers: {
+          'x-rapidapi-key': `${apiKey}`,
+          'x-rapidapi-host': 'api-football-v1.p.rapidapi.com'
+        }
+      };
+  
+    try {
+      const resFixtures = await axios.request(optionsFixtures); //pass res.data.response to cleanMatchData
+      const resStats = await axios.request(optionsStats); //return res.data.response
+      const nycData = {
+        fixturesData: resFixtures.data.response,
+        statsData: resStats.data.response,
+        lastRefresh: new Date()
+      };
+      fs.writeFile(path.join(__dirname, 'nycCache.json'), JSON.stringify(nycData, null, 2), (err) => {
+        if (err) throw err;
+        console.log('Refreshing NYCFC cache data.');
+      });
+    } catch (error) {
+      console.error(error);
+    }
+}
+
+const startRefreshNycData = async () => {
+    let nycCache = await getCache();
+    let lastRefreshTime = new Date(nycCache.lastRefresh);
+    let currentTime = new Date();
+    let timeDiff = Math.abs(lastRefreshTime.getTime() - currentTime.getTime());
+    if (timeDiff > 1800000 || !nycCache) refreshNycData();
+    setInterval(() => {
+        console.log(1)
+        refreshNycData();
+        console.log(2)
+    }, 3600000);
+}
+
+module.exports = startRefreshNycData;

--- a/bot/index.js
+++ b/bot/index.js
@@ -1,6 +1,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { Client, Collection, GatewayIntentBits } = require('discord.js');
+const startRefreshNycData = require('./helper/nycfc/refreshNycData');
 
 require('dotenv').config();
 
@@ -40,3 +41,4 @@ for (const file of eventFiles) {
 }
 
 client.login(token);
+startRefreshNycData();


### PR DESCRIPTION
- Added caching of incoming football API data
- Added loading/error message for bot in the event that caching data has not completed
- Big fixes for previous games and upcoming games display
- API token is now stored inside the .env file

The NYCFC data is requested if the bot is restarted and has not cached data in the last half hour or once every hour since the bot has started.